### PR TITLE
Persist users in SQLite and use Werkzeug hashes

### DIFF
--- a/userdaten.txt
+++ b/userdaten.txt
@@ -1,2 +1,0 @@
-leon.littwins@gmail.com,f528ddced5570ad5b2dcb29e2dd65781761249903384efe48c7ecab90a4abe33
-python,5994471abb01112afcc18159f6cc74b4f511b99806da59b3caf5a9c173cacfc5


### PR DESCRIPTION
## Summary
- store user credentials in an SQLite database
- replace custom SHA256 password hashing with Werkzeug's `generate_password_hash` and `check_password_hash`
- remove old `userdaten.txt`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac3a9b9fc0832599cf876d8bc31fc8