### PR TITLE
Load API keys from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# PythonAPI
+
+Simple Flask dashboard that shows weather, news and currency data.
+
+## Required environment variables
+
+Set the following variables before starting the application:
+
+- `NEWS_API_KEY` – API key for [NewsAPI](https://newsapi.org/).
+- `WEATHER_API_KEY` – API key for [OpenWeatherMap](https://openweathermap.org/).
+- `CURRENCY_API_KEY` – API key for [ExchangeRate API](https://www.exchangerate-api.com/).
+
+Optional variables such as `SECRET_KEY`, `SESSION_LIFETIME_MINUTES` or `USERS_DB` can also be used to further configure the application.

--- a/app.py
+++ b/app.py
@@ -181,7 +181,7 @@ def show_currencies():
     if 'username' not in session:
         flash(_("Please login first."))
         return redirect(url_for('login'))
-    return render_template('currency.html')
+    return render_template('currency.html', currency_api_key=config.CURRENCY_API_KEY)
 
 
 @app.route('/weather', methods=['GET', 'POST'])
@@ -231,7 +231,9 @@ def show_weather():
         else:
             error = _("Please enter a city name.")
 
-    return render_template('weather.html', weather=weather_data, error=error)
+    return render_template(
+        'weather.html', weather=weather_data, error=error, weather_api_key=config.WEATHER_API_KEY
+    )
 
 
 @app.route('/news')

--- a/config.py
+++ b/config.py
@@ -1,24 +1,13 @@
 """Application configuration values.
 
-The values below are loaded from environment variables when available to make
-the application easily configurable without modifying the source code. The
-defaults are only meant for development and should be replaced in production.
+All values are sourced from environment variables to keep secrets out of the
+code base. Set the variables listed below before running the application.
 """
 
 import os
 
 # Public API keys -----------------------------------------------------------------
-# These keys are read from environment variables so they can be changed without
-# touching the code base. Replace the default values with your own keys.
-
-NEWS_API_KEY = os.getenv("NEWS_API_KEY", "72ffaa246beb41a1af6d772997996e32")
-WEATHER_API_KEY = os.getenv("WEATHER_API_KEY", "0beb33baf383caabcb53cca61f1a04b8")
-
-# Base URL for the currency exchange API. The URL already contains the API key.
-# Override ``CURRENCY_API_URL`` in the environment to use a different service or
-# key.
-CURRENCY_API_URL = os.getenv(
-    "CURRENCY_API_URL",
-    "https://v6.exchangerate-api.com/v6/adc5a7aa933d9a8382bb47d5/latest/USD",
-)
+NEWS_API_KEY = os.environ["NEWS_API_KEY"]
+WEATHER_API_KEY = os.environ["WEATHER_API_KEY"]
+CURRENCY_API_KEY = os.environ["CURRENCY_API_KEY"]
 

--- a/templates/currency.html
+++ b/templates/currency.html
@@ -290,7 +290,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
 <script>
-  const apiKey = 'adc5a7aa933d9a8382bb47d5';
+  const apiKey = '{{ currency_api_key }}';
   const baseURL = 'https://v6.exchangerate-api.com/v6/' + apiKey;
 
   const selectFrom = document.getElementById('currencyFrom');

--- a/templates/weather.html
+++ b/templates/weather.html
@@ -87,7 +87,7 @@
 </div>
 
 <script>
-  const apiKey = "0beb33baf383caabcb53cca61f1a04b8";
+  const apiKey = "{{ weather_api_key }}";
 
   const weatherIcon = document.getElementById("weatherIcon");
   const tempEl = document.getElementById("temp");


### PR DESCRIPTION
## Summary
- read News, Weather and Currency API keys exclusively from environment variables
- pass required keys from Flask backend to templates
- document required environment variables in new README

## Testing
- `python -m py_compile app.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac3b8f27148325b1283a6a0a81db0c