### PR TITLE
Use FLASK_DEBUG env variable for debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# PythonAPI
+
+Simple Flask-based API demonstration.
+
+## Environment Variables
+
+- `FLASK_DEBUG`: Set to `1` to enable Flask debug mode. Use this only in development environments; omit or set to `0` in production.
+
+Other configuration values are loaded from environment variables in `config.py`.

--- a/app.py
+++ b/app.py
@@ -262,4 +262,6 @@ def show_news():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    # Enable debug mode only when FLASK_DEBUG is set to "1".
+    # This should be used for development environments only.
+    app.run(debug=os.getenv('FLASK_DEBUG') == '1')


### PR DESCRIPTION
## Summary
- Make Flask debug mode conditional on the `FLASK_DEBUG` environment variable
- Document `FLASK_DEBUG` usage in new README

## Testing
- `python -m py_compile app.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac3ba975d483258b67087ebaf7723c